### PR TITLE
fix(#24): 保険システムのバランス調整 - 過度に強力な効果を緩和

### DIFF
--- a/src/domain/constants/insurance.constants.ts
+++ b/src/domain/constants/insurance.constants.ts
@@ -1,0 +1,28 @@
+/**
+ * 保険システムのバランス調整用定数
+ * Issue #24: 保険効果の過度な強力さを緩和するための設定
+ */
+
+/**
+ * 保険によるダメージ軽減の上限値
+ * 1枚の保険カードで軽減できる最大ダメージ量
+ */
+export const MAX_DAMAGE_REDUCTION_PER_INSURANCE = 2
+
+/**
+ * 保険によるダメージ軽減の合計上限値
+ * 複数の保険を持っていても、これ以上はダメージを軽減できない
+ */
+export const MAX_TOTAL_DAMAGE_REDUCTION = 5
+
+/**
+ * 保険効果の段階的な適用レート
+ * カバレッジ値に対する実際の軽減率
+ */
+export const INSURANCE_EFFECTIVENESS_RATE = 0.5 // 50%の効果
+
+/**
+ * 保険の最小ダメージ保証
+ * どんなに保険があっても、最低限このダメージは受ける
+ */
+export const MINIMUM_DAMAGE_AFTER_INSURANCE = 1

--- a/src/domain/services/__tests__/InsuranceDamageReduction.test.ts
+++ b/src/domain/services/__tests__/InsuranceDamageReduction.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Card } from '../../entities/Card'
+import { Game } from '../../entities/Game'
+import { CardFactory } from '../CardFactory'
+import { 
+  MAX_DAMAGE_REDUCTION_PER_INSURANCE, 
+  MAX_TOTAL_DAMAGE_REDUCTION, 
+  INSURANCE_EFFECTIVENESS_RATE,
+  MINIMUM_DAMAGE_AFTER_INSURANCE 
+} from '../../constants/insurance.constants'
+
+describe('保険によるダメージ軽減の上限テスト (Issue #24)', () => {
+  let game: Game
+  
+  beforeEach(() => {
+    game = new Game({ startingVitality: 100 })
+    game.start()
+  })
+  
+  describe('単一保険カードのダメージ軽減', () => {
+    it('保険カード1枚の軽減量が上限を超えない', () => {
+      // damage_reduction効果を持つ保険カードを作成
+      const insurance = new Card({
+        id: 'test-insurance',
+        type: 'insurance',
+        name: '強力な保険',
+        description: 'テスト用保険',
+        power: 2,
+        cost: 0,  // テスト用にコストを0に設定
+        insuranceType: 'medical',
+        durationType: 'term',
+        duration: 3,
+        effects: [{
+          type: 'damage_reduction',
+          value: 10,  // 通常なら10ダメージ軽減
+          description: 'ダメージ-10'
+        }]
+      })
+      
+      // 効果率を適用した軽減量を計算
+      const expectedReduction = Math.min(
+        10 * INSURANCE_EFFECTIVENESS_RATE,
+        MAX_DAMAGE_REDUCTION_PER_INSURANCE
+      )
+      
+      expect(insurance.calculateDamageReduction()).toBe(expectedReduction)
+    })
+    
+    it('効果率が適用される', () => {
+      // damage_reduction効果を持つ保険カード
+      const insurance = new Card({
+        id: 'test-insurance-2',
+        type: 'insurance',
+        name: '通常の保険',
+        description: 'テスト用保険',
+        power: 2,
+        cost: 0,  // テスト用にコストを0に設定
+        insuranceType: 'medical',
+        durationType: 'term',
+        duration: 3,
+        effects: [{
+          type: 'damage_reduction',
+          value: 3,
+          description: 'ダメージ-3'
+        }]
+      })
+      
+      // 3 * 0.5 = 1.5
+      const expectedReduction = 3 * INSURANCE_EFFECTIVENESS_RATE
+      
+      expect(insurance.calculateDamageReduction()).toBe(expectedReduction)
+    })
+  })
+  
+  describe('複数保険カードの合計軽減', () => {
+    it('複数の保険カードの合計軽減量が上限を超えない', () => {
+      // 複数の強力な保険カードを追加（damage_reduction効果付き）
+      const insurance1 = new Card({
+        id: 'insurance-1',
+        type: 'insurance',
+        name: '保険1',
+        description: 'テスト用保険1',
+        power: 2,
+        cost: 0,  // テスト用にコストを0に設定
+        insuranceType: 'medical',
+        durationType: 'term',
+        duration: 3,
+        effects: [{
+          type: 'damage_reduction',
+          value: 5,
+          description: 'ダメージ-5'
+        }]
+      })
+      const insurance2 = new Card({
+        id: 'insurance-2',
+        type: 'insurance',
+        name: '保険2',
+        description: 'テスト用保険2',
+        power: 2,
+        cost: 0,  // テスト用にコストを0に設定
+        insuranceType: 'accident',
+        durationType: 'term',
+        duration: 3,
+        effects: [{
+          type: 'damage_reduction',
+          value: 5,
+          description: 'ダメージ-5'
+        }]
+      })
+      const insurance3 = new Card({
+        id: 'insurance-3',
+        type: 'insurance',
+        name: '保険3',
+        description: 'テスト用保険3',
+        power: 2,
+        cost: 0,  // テスト用にコストを0に設定
+        insuranceType: 'life',
+        durationType: 'term',
+        duration: 3,
+        effects: [{
+          type: 'damage_reduction',
+          value: 5,
+          description: 'ダメージ-5'
+        }]
+      })
+      
+      game.addInsurance(insurance1)
+      game.addInsurance(insurance2)
+      game.addInsurance(insurance3)
+      
+      // チャレンジでダメージを受ける（通常のチャレンジカードを直接作成）
+      const challenge = new Card({
+        id: 'test-challenge',
+        type: 'challenge',
+        name: '強力な挑戦',
+        description: 'テスト用チャレンジ',
+        power: 20,
+        category: 'health'
+      })
+      
+      // チャレンジを正式に開始
+      game.startChallenge(challenge)
+      
+      // プレイヤーパワー10で挑戦（10ダメージを受けるはず）
+      const lifeCard = Card.createLifeCard('生活カード', 10)
+      game.addCardToHand(lifeCard)
+      game.toggleCardSelection(lifeCard)
+      
+      const result = game.resolveChallenge()
+      
+      // デバッグ用ログ
+      console.log('Challenge result:', result)
+      console.log('Power breakdown:', result.powerBreakdown)
+      console.log('Insurance burden:', game.insuranceBurden)
+      console.log('Insurance cards:', game.insuranceCards.map(card => ({
+        name: card.name,
+        damageReduction: card.calculateDamageReduction()
+      })))
+      
+      // 保険料負担を考慮した正確な計算
+      const challengePower = 20
+      const basePower = 10
+      const insuranceBurden = game.insuranceBurden
+      const effectivePower = basePower - insuranceBurden // 保険料負担でパワーが減る
+      const baseDamage = challengePower - effectivePower
+      
+      // 保険軽減の計算
+      const insuranceReductions = game.insuranceCards.map(card => card.calculateDamageReduction())
+      const totalReductionBeforeLimit = insuranceReductions.reduce((sum, r) => sum + r, 0)
+      const actualReduction = Math.min(totalReductionBeforeLimit, MAX_TOTAL_DAMAGE_REDUCTION)
+      
+      // 最終ダメージ
+      const finalDamage = Math.max(baseDamage - actualReduction, MINIMUM_DAMAGE_AFTER_INSURANCE)
+      
+      console.log('Calculation details:', {
+        challengePower,
+        basePower,
+        insuranceBurden,
+        effectivePower,
+        baseDamage,
+        insuranceReductions,
+        totalReductionBeforeLimit,
+        actualReduction,
+        finalDamage
+      })
+      
+      expect(result.vitalityChange).toBe(-finalDamage)
+    })
+    
+    it('最小ダメージ保証が適用される', () => {
+      // 非常に強力な保険カードを複数追加
+      for (let i = 0; i < 5; i++) {
+        const insurance = new Card({
+          id: `insurance-${i}`,
+          type: 'insurance',
+          name: `保険${i}`,
+          description: `テスト用保険${i}`,
+          power: 2,
+          insuranceType: 'medical',
+          durationType: 'term',
+          duration: 3,
+          effects: [{
+            type: 'damage_reduction',
+            value: 10,
+            description: 'ダメージ-10'
+          }]
+        })
+        game.addInsurance(insurance)
+      }
+      
+      // 小さなチャレンジ（通常のチャレンジカードを直接作成）
+      const challenge = new Card({
+        id: 'small-challenge',
+        type: 'challenge',
+        name: '小さな挑戦',
+        description: 'テスト用チャレンジ',
+        power: 5,
+        category: 'health'
+      })
+      
+      // チャレンジを正式に開始
+      game.startChallenge(challenge)
+      
+      // プレイヤーパワー3で挑戦（2ダメージを受けるはず）
+      const lifeCard = Card.createLifeCard('生活カード', 3)
+      game.addCardToHand(lifeCard)
+      game.toggleCardSelection(lifeCard)
+      
+      const result = game.resolveChallenge()
+      
+      // どんなに保険があっても最小ダメージは受ける
+      expect(result.vitalityChange).toBe(-MINIMUM_DAMAGE_AFTER_INSURANCE)
+    })
+  })
+  
+  describe('ゲームバランスの確認', () => {
+    it('適切な保険枚数でリスク管理ができる', () => {
+      // 適度な保険2枚
+      const insurance1 = new Card({
+        id: 'moderate-insurance-1',
+        type: 'insurance',
+        name: '保険1',
+        description: 'テスト用保険1',
+        power: 2,
+        cost: 0,  // テスト用にコストを0に設定
+        insuranceType: 'medical',
+        durationType: 'term',
+        duration: 3,
+        effects: [{
+          type: 'damage_reduction',
+          value: 3,
+          description: 'ダメージ-3'
+        }]
+      })
+      const insurance2 = new Card({
+        id: 'moderate-insurance-2',
+        type: 'insurance',
+        name: '保険2',
+        description: 'テスト用保険2',
+        power: 2,
+        cost: 0,  // テスト用にコストを0に設定
+        insuranceType: 'accident',
+        durationType: 'term',
+        duration: 3,
+        effects: [{
+          type: 'damage_reduction',
+          value: 3,
+          description: 'ダメージ-3'
+        }]
+      })
+      
+      game.addInsurance(insurance1)
+      game.addInsurance(insurance2)
+      
+      // 中程度のチャレンジ（通常のチャレンジカードを直接作成）
+      const challenge = new Card({
+        id: 'medium-challenge',
+        type: 'challenge',
+        name: '中程度の挑戦',
+        description: 'テスト用チャレンジ',
+        power: 15,
+        category: 'health'
+      })
+      
+      // チャレンジを正式に開始
+      game.startChallenge(challenge)
+      
+      // プレイヤーパワー10で挑戦
+      const lifeCard = Card.createLifeCard('生活カード', 10)
+      game.addCardToHand(lifeCard)
+      game.toggleCardSelection(lifeCard)
+      
+      const result = game.resolveChallenge()
+      
+      // 基本ダメージ: 15 - 10 = 5
+      // 保険軽減: 3 * 0.5 * 2 = 3（各保険1.5、合計3）
+      // 実際のダメージ: 5 - 3 = 2
+      expect(result.vitalityChange).toBe(-2)
+    })
+    
+    it('保険がない場合は全ダメージを受ける', () => {
+      // 保険なし（通常のチャレンジカードを直接作成）
+      const challenge = new Card({
+        id: 'no-insurance-challenge',
+        type: 'challenge',
+        name: '挑戦',
+        description: 'テスト用チャレンジ',
+        power: 15,
+        category: 'health'
+      })
+      
+      // チャレンジを正式に開始
+      game.startChallenge(challenge)
+      
+      const lifeCard = Card.createLifeCard('生活カード', 10)
+      game.addCardToHand(lifeCard)
+      game.toggleCardSelection(lifeCard)
+      
+      const result = game.resolveChallenge()
+      
+      // 基本ダメージ: 15 - 10 = 5（軽減なし）
+      expect(result.vitalityChange).toBe(-5)
+    })
+  })
+})


### PR DESCRIPTION
## 🎯 Issue
Closes #24

## 📋 概要
保険カードによるダメージ軽減が過度に強力で、リスクが実質的に存在しない状態を改善しました。

## 🔧 変更内容

### 1. 保険効果の段階的な適用
- **効果率**: カバレッジ値の50%のみが実際の軽減量に（`INSURANCE_EFFECTIVENESS_RATE = 0.5`）
- **理由**: 保険の効果を段階的にすることで、より現実的なリスク軽減を実現

### 2. 単一保険カードの上限
- **上限値**: 1枚の保険カードで最大2ダメージまで軽減（`MAX_DAMAGE_REDUCTION_PER_INSURANCE = 2`）
- **理由**: 単一の保険に過度に依存することを防ぐ

### 3. 複数保険の合計上限
- **上限値**: 複数の保険を持っていても合計で最大5ダメージまで（`MAX_TOTAL_DAMAGE_REDUCTION = 5`）
- **理由**: 保険の数を増やすだけでは完全な安全を得られないようにする

### 4. 最小ダメージ保証
- **最小値**: どんなに保険があっても最低1ダメージは受ける（`MINIMUM_DAMAGE_AFTER_INSURANCE = 1`）
- **理由**: リスクの完全排除を防ぎ、常に緊張感を保つ

## 📊 バランスの変化

### Before（変更前）
- 保険カード1枚で10ダメージを完全無効化可能
- 複数の保険で実質的に無敵状態

### After（変更後）
- 保険カード1枚で最大2ダメージ軽減
- 複数持っても最大5ダメージ軽減
- 必ず最低1ダメージは受ける

## 🧪 テスト
以下のテストケースを追加し、全て成功を確認：
- ✅ 単一保険カードの軽減量が上限を超えない
- ✅ 効果率が正しく適用される
- ✅ 複数保険の合計軽減量が上限を超えない
- ✅ 最小ダメージ保証が適用される
- ✅ 適切な保険枚数でリスク管理ができる
- ✅ 保険がない場合は全ダメージを受ける

## 🎮 ゲームプレイへの影響
1. **戦略性の向上**: 保険の選択がより重要に
2. **リスク管理**: 完全な安全はなく、常にリスクと向き合う必要がある
3. **緊張感の維持**: 最小ダメージ保証により、常に慎重なプレイが必要

## 📝 技術的な詳細
- `src/domain/constants/insurance.constants.ts`: バランス調整用定数を新規作成
- `src/domain/entities/Card.ts`: `calculateDamageReduction()`メソッドを修正
- `src/domain/services/ChallengeResolutionService.ts`: 軽減計算と最小ダメージ保証を実装
- `src/domain/services/__tests__/InsuranceDamageReduction.test.ts`: 包括的なテストスイートを追加

🤖 Generated with [Claude Code](https://claude.ai/code)