### PR TITLE
fix: Browser console errors - font preload 404 and favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -216,8 +216,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     
-    <!-- フォントのプリロード -->
-    <link rel="preload" as="font" type="font/woff2" href="https://fonts.gstatic.com/s/notosansjp/v52/-F6jfjtqLzI2JPCgQBnw7HFyzSD-AsregP8VFBEi75vY0rw-oME.woff2" crossorigin>
+    <!-- フォントのプリロード - 削除: 404エラーを回避 -->
+    <!-- <link rel="preload" as="font" type="font/woff2" href="https://fonts.gstatic.com/s/notosansjp/v52/-F6jfjtqLzI2JPCgQBnw7HFyzSD-AsregP8VFBEi75vY0rw-oME.woff2" crossorigin> -->
     
     <!-- Resource Hints でパフォーマンス向上 -->
     <link rel="prefetch" href="/manifest.json">


### PR DESCRIPTION
## Summary
- Removed problematic font preload link that was causing 404 error
- Verified favicon.ico and favicon.svg files exist in public directory

## Issue Fixed
Fixes #37

## Changes Made
1. Commented out the font preload link in index.html that was causing 404 error
2. Confirmed favicon files are properly placed in public directory

## Test Results
- Font preload 404 error should no longer appear in console
- Favicon should load correctly from /favicon.ico and /favicon.svg

🤖 Generated with [Claude Code](https://claude.ai/code)