### PR TITLE
fix: Service Worker のパス問題を修正 (#39)

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -19,8 +19,8 @@ const IMAGES_CACHE_NAME = `life-fulfillment-images-v${CACHE_VERSION}`;
 const API_CACHE_NAME = `life-fulfillment-api-v${CACHE_VERSION}`;
 
 // 必須の静的ファイル（即座にキャッシュ）
-// GitHub Pagesのサブディレクトリに対応
-const BASE_PATH = '/insurance_self_game';
+// BASE_PATHは self.location.pathname から動的に取得
+const BASE_PATH = self.location.pathname.replace(/\/[^/]*$/, '').replace(/\/$/, '') || '';
 const CRITICAL_STATIC_FILES = [
   `${BASE_PATH}/`,
   `${BASE_PATH}/index.html`,

--- a/src/utils/pwa-manager.ts
+++ b/src/utils/pwa-manager.ts
@@ -101,8 +101,8 @@ export class PWAManager {
     }
 
     try {
-      const registration = await navigator.serviceWorker.register('/service-worker.js', {
-        scope: '/',
+      const registration = await navigator.serviceWorker.register(`${import.meta.env.BASE_URL}service-worker.js`, {
+        scope: import.meta.env.BASE_URL,
         updateViaCache: 'none'
       })
 
@@ -247,7 +247,7 @@ export class PWAManager {
       await this.sendNotification({
         title: '人生充実ゲーム',
         body: '新しいチャレンジが待っています！プレイを再開しませんか？',
-        icon: '/favicon.ico',
+        icon: `${import.meta.env.BASE_URL}favicon.ico`,
         tag: 'game-reminder',
         data: {
           action: 'resume-game',
@@ -449,9 +449,9 @@ export class PWAManager {
     if (!this.serviceWorker) return
 
     const criticalAssets = [
-      '/manifest.json',
-      '/favicon.ico',
-      '/favicon.svg'
+      `${import.meta.env.BASE_URL}manifest.json`,
+      `${import.meta.env.BASE_URL}favicon.ico`,
+      `${import.meta.env.BASE_URL}favicon.svg`
     ]
 
     try {

--- a/src/utils/serviceWorkerManager.ts
+++ b/src/utils/serviceWorkerManager.ts
@@ -49,8 +49,8 @@ class ServiceWorkerManager {
     }
 
     try {
-      this.registration = await navigator.serviceWorker.register('/service-worker.js', {
-        scope: '/',
+      this.registration = await navigator.serviceWorker.register(`${import.meta.env.BASE_URL}service-worker.js`, {
+        scope: import.meta.env.BASE_URL,
         updateViaCache: 'none' // 常に最新版をチェック
       })
 


### PR DESCRIPTION
## 概要
Issue #39で報告された、GitHub Pages デプロイ時の Service Worker パス問題を修正しました。

## 問題の原因
- Service Worker のパスがハードコード（`/service-worker.js`）されていた
- GitHub Pages はサブディレクトリ（`/insurance_self_game/`）から提供される
- これにより Service Worker 読み込み時に404エラーが発生していた

## 修正内容
1. **pwa-manager.ts**
   - Service Worker 登録パスを `import.meta.env.BASE_URL` を使用するように変更
   - アセット（manifest.json, favicon等）のパスも動的に設定

2. **serviceWorkerManager.ts**
   - Service Worker 登録パスを動的に設定

3. **service-worker.js**
   - BASE_PATH を `self.location.pathname` から動的に取得するように変更

## テスト
- ローカルビルドの成功を確認 ✅
- Service Worker ファイルが正しく配置されることを確認 ✅

## 関連Issue
- Closes #39

🤖 Generated with [Claude Code](https://claude.ai/code)